### PR TITLE
Pr 748

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,7 @@ files:
   - if `true`, create release as draft
 - `pre_release`
   - if `true`, create release as pre release
-- `force_versioning`: Manually sets the version via the current_version and next_version arguments
-- `current_version`: The current version
-- `next_version`: The updated version
-
+- `force_versioning`: Manually sets the version. Expected string format: "current_version => next_version" 
 ## Output
 - `current_version`
   - calculated current version

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ files:
   - if `true`, create release as draft
 - `pre_release`
   - if `true`, create release as pre release
+- `force_versioning`: Manually sets the version via the current_version and next_version arguments
+- `current_version`: The current version
+- `next_version`: The updated version
 
 ## Output
 - `current_version`

--- a/__test__/release.test.ts
+++ b/__test__/release.test.ts
@@ -17,6 +17,9 @@ function createOption(): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
+        useExtTool: false,
+        currentVersion: "",
+        nextVersion: "",
     };
 }
 

--- a/__test__/release.test.ts
+++ b/__test__/release.test.ts
@@ -17,9 +17,7 @@ function createOption(): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
-        forceVersioning: false,
-        currentVersion: "",
-        nextVersion: "",
+        forceVersioning: "",
     };
 }
 

--- a/__test__/release.test.ts
+++ b/__test__/release.test.ts
@@ -17,7 +17,7 @@ function createOption(): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
-        useExtTool: false,
+        forceVersioning: false,
         currentVersion: "",
         nextVersion: "",
     };

--- a/__test__/version.test.ts
+++ b/__test__/version.test.ts
@@ -18,7 +18,7 @@ function createOption(defaultBump: Version | null): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
-        useExtTool: false,
+        forceVersioning: false,
         currentVersion: "",
         nextVersion: "",
     };

--- a/__test__/version.test.ts
+++ b/__test__/version.test.ts
@@ -18,6 +18,9 @@ function createOption(defaultBump: Version | null): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
+        useExtTool: false,
+        currentVersion: "",
+        nextVersion: "",
     };
 }
 

--- a/__test__/version.test.ts
+++ b/__test__/version.test.ts
@@ -18,9 +18,7 @@ function createOption(defaultBump: Version | null): Option {
         dryRun: false,
         preRelease: false,
         draft: false,
-        forceVersioning: false,
-        currentVersion: "",
-        nextVersion: "",
+        forceVersioning: "",
     };
 }
 

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,12 @@ inputs:
   base_url:
     description: "The where the repo is hosted."
     default: "github.com"
+  use_ext_tool:
+    description: 'if external tool is used, the current_version and next_version inputs will be used'
+  current_version:
+    description: 'the current semver'
+  next_version:
+    description: 'the updated semver'
 outputs:
   current_version:
     description: 'calculated current version'

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ inputs:
   base_url:
     description: "The where the repo is hosted."
     default: "github.com"
-  use_ext_tool:
-    description: 'if external tool is used, the current_version and next_version inputs will be used'
+  force_versioning:
+    description: 'Manually set the version using the current / next version fields'
   current_version:
     description: 'the current semver'
   next_version:

--- a/action.yml
+++ b/action.yml
@@ -36,11 +36,7 @@ inputs:
     description: "The where the repo is hosted."
     default: "github.com"
   force_versioning:
-    description: 'Manually set the version using the current / next version fields'
-  current_version:
-    description: 'the current semver'
-  next_version:
-    description: 'the updated semver'
+    description: 'Manually set the version'
 outputs:
   current_version:
     description: 'calculated current version'

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,14 +31,25 @@ async function run() {
         }
         const commitAndPullRequests = await listPullRequests(client, option, config, commits);
         const changes = calculateChanges(config, commitAndPullRequests);
-        const currentVersion = calculateCurrentVersion(config, latestRelease);
-        const nextVersion = calculateNextVersion(option, config, latestRelease, changes);
-
-        const hasChanges = replaceVersions(option, config, nextVersion);
-        if (hasChanges) {
-            await pushBaseBranch(option, config, nextVersion);
-        }
-        await pushVersionBranch(option, config, nextVersion);
+        
+        var currentVersion;
+        var nextVersion;
+        
+        if (option.useExtTool) {
+			currentVersion = option.currentVersion;
+			nextVersion = option.nextVersion;
+		}
+		else {
+			currentVersion = calculateCurrentVersion(config, latestRelease);
+			nextVersion = calculateNextVersion(option, config, latestRelease, changes);			
+		}
+		
+		const hasChanges = replaceVersions(option, config, nextVersion);
+		if (hasChanges) {
+			await pushBaseBranch(option, config, nextVersion);
+		}
+		await pushVersionBranch(option, config, nextVersion);
+		
         const createdReleaseJson = await createRelease(client, option, config, nextVersion, changes);
 
         core.info("");

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function run() {
         var currentVersion;
         var nextVersion;
         
-        if (option.useExtTool) {
+        if (option.forceVersioning) {
 			currentVersion = option.currentVersion;
 			nextVersion = option.nextVersion;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,12 +32,12 @@ async function run() {
         const commitAndPullRequests = await listPullRequests(client, option, config, commits);
         const changes = calculateChanges(config, commitAndPullRequests);
         
-        var currentVersion;
-        var nextVersion;
-        
-        if (option.forceVersioning) {
-			currentVersion = option.currentVersion;
-			nextVersion = option.nextVersion;
+        const forceVersioning: string | null = option.forceVersioning;
+		var [currentVersion, nextVersion] = forceVersioning?.split("=>").map((item: string) => item.trim()) ?? [undefined, undefined]
+		if (currentVersion != undefined && currentVersion != "" && nextVersion != undefined && nextVersion != "") {
+			if (currentVersion == nextVersion) {       
+				throw new Error(`current version(${currentVersion}) is the same as next version(${nextVersion})`);
+			}
 		}
 		else {
 			currentVersion = calculateCurrentVersion(config, latestRelease);

--- a/src/option.ts
+++ b/src/option.ts
@@ -12,9 +12,7 @@ export interface Option {
     dryRun: boolean;
     preRelease: boolean;
     draft: boolean;
-    forceVersioning: boolean;
-    currentVersion: string;
-    nextVersion: string;
+    forceVersioning: string | null;
 }
 
 export function getOption(): Option {
@@ -29,9 +27,7 @@ export function getOption(): Option {
         dryRun: getInputOrNull("dry_run") == "true",
         preRelease: getInputOrNull("pre_release") == "true",
         draft: getInputOrNull("draft") == "true",
-        forceVersioning: getInputOrNull("force_versioning") == "true",
-        currentVersion: getInput("current_version"),
-        nextVersion: getInput("next_version"),
+        forceVersioning: getInput("force_versioning"),
     };
 }
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -12,7 +12,7 @@ export interface Option {
     dryRun: boolean;
     preRelease: boolean;
     draft: boolean;
-    useExtTool: boolean;
+    forceVersioning: boolean;
     currentVersion: string;
     nextVersion: string;
 }
@@ -29,7 +29,7 @@ export function getOption(): Option {
         dryRun: getInputOrNull("dry_run") == "true",
         preRelease: getInputOrNull("pre_release") == "true",
         draft: getInputOrNull("draft") == "true",
-        useExtTool: getInputOrNull("use_ext_tool") == "true",
+        forceVersioning: getInputOrNull("force_versioning") == "true",
         currentVersion: getInput("current_version"),
         nextVersion: getInput("next_version"),
     };

--- a/src/option.ts
+++ b/src/option.ts
@@ -7,11 +7,14 @@ export interface Option {
     commitEmail: string;
     repository: string;
     baseURL: string;
-    configPath: string;
+    configPath: string;    
     bump: Version | null;
     dryRun: boolean;
     preRelease: boolean;
     draft: boolean;
+    useExtTool: boolean;
+    currentVersion: string;
+    nextVersion: string;
 }
 
 export function getOption(): Option {
@@ -26,6 +29,9 @@ export function getOption(): Option {
         dryRun: getInputOrNull("dry_run") == "true",
         preRelease: getInputOrNull("pre_release") == "true",
         draft: getInputOrNull("draft") == "true",
+        useExtTool: getInputOrNull("use_ext_tool") == "true",
+        currentVersion: getInput("current_version"),
+        nextVersion: getInput("next_version"),
     };
 }
 


### PR DESCRIPTION
Adds an option to use an external tool for versioning.
If the flag is set, 2 more variables are required - 1 to set the current version, and another to set the next (updated) version.

Not sure what's the best way to make the 2 version variables required, but only when the external tool flag is set. Any suggestions? 

